### PR TITLE
Updated Dockerfiles

### DIFF
--- a/3.7/glacier2/Dockerfile
+++ b/3.7/glacier2/Dockerfile
@@ -1,18 +1,35 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 
 LABEL maintainer="docker-maintainers@zeroc.com"
 
-ARG GLACIER2_VERSION=3.7.8
-
+ARG GLACIER2_VERSION=3.7.9
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv B6391CB2CFBA643D \
-    && echo "deb http://download.zeroc.com/Ice/3.7/ubuntu16.04 stable main" >> /etc/apt/sources.list.d/ice.list \
-    && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests -y \
-        zeroc-glacier2=${GLACIER2_VERSION}-* \
+RUN groupadd -r ice && useradd -r -g ice ice
+
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+    ca-certificates \
+    curl \
+    gpg \
+    gosu \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://zeroc.com/download/GPG-KEY-zeroc-release-B6391CB2CFBA643D |  gpg --dearmor -o /etc/apt/keyrings/zeroc.gpg \
+    && echo \
+    "deb [signed-by=/etc/apt/keyrings/zeroc.gpg] https://zeroc.com/download/ice/3.7/ubuntu22.04 stable main" | tee /etc/apt/sources.list.d/zeroc-ice-3.7.list
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+    zeroc-glacier2=${GLACIER2_VERSION}-* \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN sed -i '/^Ice\.UseSystemdJournal=1/d' /etc/glacier2router.conf \
+    && sed -i 's/^Glacier2\.Client.Endpoints=.*/Glacier2\.Client\.Endpoints=tcp -h 0\.0\.0\.0 -p 4063/' /etc/glacier2router.conf \
+    && sed -i 's/^Glacier2\.Server\.Endpoints=*/#Glacier2\.Server\.Endpoints=/' /etc/glacier2router.conf
 
 EXPOSE 4063 4064
 
-ENTRYPOINT ["/usr/bin/glacier2router", "--Ice.Config=/etc/glacier2router.conf"]
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["glacier2router", "--Ice.Config=/etc/glacier2router.conf"]

--- a/3.7/glacier2/README.md
+++ b/3.7/glacier2/README.md
@@ -1,7 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
--   [`latest`, `3.7`, `3.7.8` (*3.7/glacier2/Dockerfile*)](https://github.com/zeroc-ice/ice-dockerfiles/blob/master/3.7/glacier2/Dockerfile)
--   [`3.6`, `3.6.5` (*3.6/glacier2/Dockerfile*)](https://github.com/zeroc-ice/ice-dockerfiles/blob/master/3.6/glacier2/Dockerfile)
+- [`latest`, `3.7`, `3.7.9` (*3.7/glacier2/Dockerfile*)](https://github.com/zeroc-ice/ice-dockerfiles/blob/master/3.7/glacier2/Dockerfile)
+- [`3.6`, `3.6.5` (*3.6/glacier2/Dockerfile*)](https://github.com/zeroc-ice/ice-dockerfiles/blob/master/3.6/glacier2/Dockerfile)
 
 # What is Glacier2?
 
@@ -11,118 +11,16 @@
 
 ## Start `glacier2` service
 
+Using a configuration file:
+
+```shell
+docker run --detach --name glacier2router -p 4063:4063 -v /path/to/config:/etc/glacier2router.conf:ro zeroc/glacier2
 ```
-docker run --name some-glacier2 -v /path/to/config:/etc/glacier2router.conf:ro -d zeroc/glacier2
+
+Using command line arguments:
+
+```shell
+docker run --detach --name glacier2router -p 4063:4063 zeroc/glacier2
 ```
 
 Refer to the  [Glacier2 documentation](https://doc.zeroc.com/display/Ice/Glacier2) for more information on how to configure Glacier2.
-
-## Exposing ports
-
-```
-docker run --name some-glacier2 -p 4063-4064:4063-4064 -v /path/to/config:/etc/glacier2router.conf:ro -d zeroc/glacier2
-```
-
-## Sample Configuration
-
-```
-#
-# Set the instance name
-#
-Glacier2.InstanceName=MyGlacier2Router
-
-#
-# The client-visible endpoint of Glacier2. This should be an endpoint
-# visible from the public Internet, and it should be secure.
-# IANA-registered TCP ports for the Glacier2 router:
-# - 4063 (insecure)
-# - 4064 (secure, using SSL)
-#
-# Using tcp is not recommended for production!
-#
-Glacier2.Client.Endpoints=tcp -p 4063 -h <docker image name>
-#Glacier2.Client.Endpoints=ssl -p 4064 -h <docker image name>
-
-#
-# The server-visible endpoint of Glacier2. This endpoint is only
-# required if callbacks are needed (leave empty otherwise). This
-# should be an endpoint on an internal network (like 192.168.x.x), or
-# on the loopback, so that the server is not directly accessible from
-# the Internet.
-#
-Glacier2.Server.Endpoints=tcp -h <docker image name>  -p <some port>
-
-#
-# This permissions verifier allows any user-id / password combination;
-# this is not recommended for production!
-#
-Glacier2.PermissionsVerifier=MyGlacier2Router/NullPermissionsVerifier
-
-#
-# The timeout for inactive sessions. If any client session is inactive
-# for longer than this value, the session expires and is removed. The
-# unit is seconds.
-#
-Glacier2.SessionTimeout=30
-
-#
-# Glacier2 always disables active connection management so there is no
-# need to configure this manually. Connection retry does not need to
-# be disabled, as it's safe for Glacier2 to retry outgoing connections
-# to servers. Retry for incoming connections from clients must be
-# disabled in the clients.
-#
-
-#
-# Various settings to trace requests, overrides, etc.
-#
-Ice.UseSyslog=1
-Glacier2.Client.Trace.Request=1
-Glacier2.Server.Trace.Request=1
-Glacier2.Client.Trace.Override=1
-Glacier2.Server.Trace.Override=1
-Glacier2.Client.Trace.Reject=1
-Glacier2.Trace.Session=1
-Glacier2.Trace.RoutingTable=1
-
-#
-# Warn about connection exceptions
-#
-Ice.Warn.Connections=1
-
-#
-# Network Tracing
-#
-# 0 = no network tracing
-# 1 = trace connection establishment and closure
-# 2 = like 1, but more detailed
-# 3 = like 2, but also trace data transfer
-#
-#Ice.Trace.Network=1
-
-#
-# Protocol Tracing
-#
-# 0 = no protocol tracing
-# 1 = trace protocol messages
-#
-#Ice.Trace.Protocol=1
-
-#
-# Security Tracing
-#
-# 0 = no security tracing
-# 1 = trace messages
-#
-#IceSSL.Trace.Security=1
-
-#
-# SSL Configuration
-#
-#Ice.Plugin.IceSSL=IceSSL:createIceSSL
-
-#IceSSL.DefaultDir=<path to certs dir>
-
-#IceSSL.CertAuthFile=cacert.pem
-#IceSSL.CertFile=server.p12
-```

--- a/3.7/glacier2/docker-entrypoint.sh
+++ b/3.7/glacier2/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- glacier2router --Ice.Config=/etc/glacier2router.conf "$@"
+fi
+
+if [ "$1" = "glacier2router" ]; then
+    echo "starting Glacier2 router..."
+    exec gosu ice "$@"
+fi
+
+exec "$@"

--- a/3.7/icegridnode/Dockerfile
+++ b/3.7/icegridnode/Dockerfile
@@ -1,20 +1,40 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 
 LABEL maintainer="docker-maintainers@zeroc.com"
 
-ARG ICEGRID_VERSION=3.7.8
-
+ARG ICEGRID_VERSION=3.7.9
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv B6391CB2CFBA643D \
-    && echo "deb http://download.zeroc.com/Ice/3.7/ubuntu16.04 stable main" > /etc/apt/sources.list.d/ice.list \
-    && apt-get update \
+RUN groupadd -r ice && useradd -r -m -d /var/lib/ice -g ice ice
+
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+    ca-certificates \
+    curl \
+    gpg \
+    gosu \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://zeroc.com/download/GPG-KEY-zeroc-release-B6391CB2CFBA643D |  gpg --dearmor -o /etc/apt/keyrings/zeroc.gpg \
+    && echo \
+    "deb [signed-by=/etc/apt/keyrings/zeroc.gpg] https://zeroc.com/download/ice/3.7/ubuntu22.04 stable main" | tee /etc/apt/sources.list.d/zeroc-ice-3.7.list
+
+RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
     zeroc-icegrid=${ICEGRID_VERSION}-* \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN sed -i '/^Ice.UseSystemdJournal=1/d' /etc/icegridnode.conf \
+    && sed -i 's/^IceGrid\.Node\.Data=.*/IceGrid\.Node\.Data=\/var\/lib\/ice\/icegrid/' /etc/icegridnode.conf \
+    && sed -i 's/^IceGrid\.Node\.Output=.*/#IceGrid\.Node\.Output=\/var\/lib\/ice\/icegrid/' /etc/icegridnode.conf \
+    && sed -i 's/^Ice.Default.Locator=.*/#Ice.Default.Locator=/' /etc/icegridnode.conf \
+    && sed -i 's/IceGrid.Node.Endpoints=.*/IceGrid.Node.Endpoints=tcp -h 0\.0\.0\.0/' /etc/icegridnode.conf
 
 EXPOSE 4061 4062
 
 VOLUME ["/var/lib/ice/icegrid"]
 
-ENTRYPOINT ["/usr/bin/icegridnode", "--Ice.Config=/etc/icegridnode.conf", "--IceGrid.Node.Data=/var/lib/ice/icegrid"]
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["icegridnode", "--Ice.Config=/etc/icegridnode.conf"]

--- a/3.7/icegridnode/README.md
+++ b/3.7/icegridnode/README.md
@@ -11,8 +11,16 @@
 
 ## Start `icegridnode` service
 
+Using a configuration file:
+
+```shell
+docker run --detach --name some-icegridnode -v data:/var/lib/ice/icegrid -v /path/to/config/:/etc/icegridnode.conf:ro zeroc/icegridnode
 ```
-docker run --name some-icegridnode -v /path/to/config/:/etc/icegridnode.conf:ro -d zeroc/icegridnode
+
+Using command line arguments:
+
+```shell
+docker run --detach --name some-icegridnode zeroc/icegridnode -v data:/var/lib/ice/icegrid --IceGrid.Node.Name=MyNode --Ice.Default.Locator="IceGrid/Locator:tcp -h icegridregistry -p 4061"
 ```
 
 Refer to the  [IceGrid documentation](https://doc.zeroc.com/display/Ice/IceGrid) for more information on how to configure an IceGrid Node.
@@ -20,51 +28,3 @@ Refer to the  [IceGrid documentation](https://doc.zeroc.com/display/Ice/IceGrid)
 ## Data volume
 
 The IceGrid Node container stores its data in a Docker volume mounted at `/var/lib/ice/icegrid`.
-
-```
-docker run --name some-icegridnode -v /path/to/config:/etc/icegridnode.conf:ro -v /path/to/folder:/var/lib/ice/icegrid -d zeroc/icegridnode
-```
-
-## Sample Configuration
-
-```
-#
-# Sample configuration file for the IceGrid node daemon
-#
-
-#
-# Proxy to the IceGrid registry
-#
-Ice.Default.Locator=DemoIceGrid/Locator:tcp -h <docker icegrid registry name>  -p 4061
-#Ice.Default.Locator=DemoIceGrid/Locator:ssl -h <docker icegrid registry name>  -p 4062
-
-#
-# The name of this node; must be unique within an IceGrid deployment
-#
-IceGrid.Node.Name=node1
-
-#
-# The node object adapter listens on the loopback interface using an
-# OS-assigned port
-#
-# These endpoints must be accessible to IceGrid registries.
-#
-# Note that access to these endpoints can pose a security
-# risk (remote code execution) and therefore these endpoints should be
-# secured. See the Ice manual for more information.
-#
-IceGrid.Node.Endpoints=tcp -h <docker image name> -p <some port>
-
-#
-# Redirect the servers'stdout and stderr to files in this directory:
-#
-IceGrid.Node.Output=/var/lib/ice/icegrid
-#IceGrid.Node.RedirectErrToOut=1
-
-#
-# Logging to syslog
-#
-Ice.UseSyslog=1
-Ice.ProgramName=icegridnode (DemoIceGrid node1)
-IceGrid.Node.Trace.Replica=2
-```

--- a/3.7/icegridnode/docker-entrypoint.sh
+++ b/3.7/icegridnode/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- icegridnode --Ice.Config=/etc/icegridnode.conf "$@"
+fi
+
+if [ "$1" = "icegridnode" ]; then
+    echo "starting icegridnode..."
+    chown -R ice:ice /var/lib/ice/icegrid
+    exec gosu ice "$@"
+fi
+
+exec "$@"

--- a/3.7/icegridregistry/Dockerfile
+++ b/3.7/icegridregistry/Dockerfile
@@ -1,20 +1,39 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 
 LABEL maintainer="docker-maintainers@zeroc.com"
 
-ARG ICEGRID_VERSION=3.7.8
-
+ARG ICEGRID_VERSION=3.7.9
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv B6391CB2CFBA643D \
-    && echo "deb http://download.zeroc.com/Ice/3.7/ubuntu16.04 stable main" >> /etc/apt/sources.list.d/ice.list \
-    && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests -y \
-            zeroc-icegrid=${ICEGRID_VERSION}-* \
+RUN groupadd -r ice && useradd -r -m -d /var/lib/ice -g ice ice
+
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+    ca-certificates \
+    curl \
+    gpg \
+    gosu \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://zeroc.com/download/GPG-KEY-zeroc-release-B6391CB2CFBA643D |  gpg --dearmor -o /etc/apt/keyrings/zeroc.gpg \
+    && echo \
+    "deb [signed-by=/etc/apt/keyrings/zeroc.gpg] https://zeroc.com/download/ice/3.7/ubuntu22.04 stable main" | tee /etc/apt/sources.list.d/zeroc-ice-3.7.list
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+    zeroc-icegrid=${ICEGRID_VERSION}-* \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN sed -i '/^Ice.UseSystemdJournal=1/d' /etc/icegridregistry.conf \
+    && sed -i 's/^IceGrid\.Registry\.Client\.Endpoints=.*/IceGrid\.Registry\.Client\.Endpoints=tcp -h 0\.0\.0\.0 -p 4061/' /etc/icegridregistry.conf \
+    && sed -i 's/^IceGrid\.Registry\.Server\.Endpoints=.*/IceGrid\.Registry\.Server\.Endpoints=tcp -h 0\.0\.0\.0/' /etc/icegridregistry.conf \
+    && sed -i 's/^IceGrid\.Registry\.Internal\.Endpoints=.*/IceGrid\.Registry\.Internal\.Endpoints=tcp -h 0\.0\.0\.0/' /etc/icegridregistry.conf
 
 EXPOSE 4061 4062
 
-VOLUME ["/var/lib/ice/icegrid"]
+VOLUME ["/var/lib/ice/icegrid/"]
 
-ENTRYPOINT ["/usr/bin/icegridregistry", "--Ice.Config=/etc/icegridregistry.conf", "--IceGrid.Registry.LMDB.Path=/var/lib/ice/icegrid"]
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["icegridregistry", "--Ice.Config=/etc/icegridregistry.conf"]

--- a/3.7/icegridregistry/README.md
+++ b/3.7/icegridregistry/README.md
@@ -2,88 +2,25 @@
 
 -   [`latest`, `3.7`, `3.7.8` (*3.7/icegridregistry/Dockerfile*)](https://github.com/zeroc-ice/ice-dockerfiles/blob/master/3.7/icegridregistry/Dockerfile)
 -   [`3.6`, `3.6.5` (*3.6/icegridregistry/Dockerfile*)](https://github.com/zeroc-ice/ice-dockerfiles/blob/master/3.6/icegridregistry/Dockerfile)
-
-# What is IceGrid?
+## What is IceGrid?
 
 [IceGrid](https://zeroc.com/products/ice/services/icegrid) is a location and activation service for [Ice](https://zeroc.com) applications.
+## How to use this image
+### Start `icegridregistry` service
 
-# How to use this image
+Using a configuration file:
 
-## Start `icegridregistry` service
-
+```shell
+docker run --detach --name some-icegridregistry -v data:/var/lib/ice/icegrid -v /path/to/config/:/etc/icegridregistry.conf:ro zeroc/icegridregistry
 ```
-docker run --name some-icegridregistry -v /path/to/config/:/etc/icegridregistry.conf:ro -d zeroc/icegridregistry
+
+Using command line arguments:
+
+```shell
+docker run --detach --name some-icegridregistry -p 4061:4061 -v data:/var/lib/ice/icegrid zeroc/icegridregistry --IceGrid.Registry.Name=MyRegistry
 ```
 
 Refer to the  [IceGrid documentation](https://doc.zeroc.com/display/Ice/IceGrid) for more information on how to configure an IceGrid Registry.
-
-## Data volume
+### Data volume
 
 The IceGrid Registry container stores its data in a Docker volume mounted at `/var/lib/ice/icegrid`.
-
-```
-docker run --name some-icegridregistry -v /path/to/config:/etc/icegridregistry.conf:ro -v /path/to/folder:/var/lib/ice/icegrid -d zeroc/icegridregistry
-```
-
-## Sample Configuration
-
-```
-#
-# Sample configuration file for the IceGrid registry daemon
-#
-
-#
-# The IceGrid instance name; must be unique, to distinguish several
-# IceGrid deployments
-#
-IceGrid.InstanceName=DemoIceGrid
-
-#
-# Client object adapter: listens on the loopback interface
-# IANA-registered TCP ports for the IceGrid registry:
-# - 4061 (insecure)
-# - 4062 (secure, using SSL)
-#
-# These endpoints must be accessible to Ice clients and servers as
-# well as the IceGrid administrative utilities.
-IceGrid.Registry.Client.Endpoints=tcp -p 4061 -h <docker image name>
-#IceGrid.Registry.Client.Endpoints=ssl -p 4062 -h <docker image name>
-#IceGrid.Registry.Client.Endpoints=tcp -p 4061 -h <docker image name>:ssl -p 4062 -h <docker image name>
-
-#
-# Server and Internal object adapters: listens on the loopback
-# interface using an OS-assigned port number.
-#
-# The Server endpoints must be accessible to Ice servers deployed on
-# IceGrid nodes or to Ice servers using IceGrid dynamic
-# registration. The Internal endpoints must be accessible to IceGrid
-# nodes.
-#
-# Note that access to these endpoints can pose a security
-# risk (remote code execution) and therefore these endpoints should be
-# secured. See the Ice manual for more information.
-#
-IceGrid.Registry.Server.Endpoints=tcp -h <docker image name> -p <some port>
-IceGrid.Registry.Internal.Endpoints=tcp -h <docker image name> -p <some port>
-
-#
-# Authentication/authorization
-# With NullPermissionsVerifier, any password is accepted (not recommended
-# for production)
-#
-IceGrid.Registry.PermissionsVerifier=DemoIceGrid/NullPermissionsVerifier
-IceGrid.Registry.AdminPermissionsVerifier=DemoIceGrid/NullPermissionsVerifier
-
-#
-# Default templates
-#
-IceGrid.Registry.DefaultTemplates=/usr/share/Ice-3.6.2/templates.xml
-
-#
-# Logging to syslog
-#
-Ice.UseSyslog=1
-Ice.ProgramName=icegridregistry (DemoIceGrid Master)
-IceGrid.Registry.Trace.Node=1
-IceGrid.Registry.Trace.Replica=1
-```

--- a/3.7/icegridregistry/docker-entrypoint.sh
+++ b/3.7/icegridregistry/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- icegridregistry --Ice.Config=/etc/icegridregistry.conf "$@"
+fi
+
+if [ "$1" = "icegridregistry" ]; then
+    echo "starting icegridregistry..."
+    chown -R ice:ice /var/lib/ice/icegrid
+    exec gosu ice "$@"
+fi
+
+exec "$@"

--- a/3.7/icestorm/Dockerfile
+++ b/3.7/icestorm/Dockerfile
@@ -1,21 +1,33 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 
 LABEL maintainer="docker-maintainers@zeroc.com"
 
-ARG ICEBOX_VERSION=3.7.8
-
+ARG ICEBOX_VERSION=3.7.9
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv B6391CB2CFBA643D \
-    && echo "deb http://download.zeroc.com/Ice/3.7/ubuntu16.04 stable main" >> /etc/apt/sources.list.d/ice.list \
-    && apt-get update \
+RUN groupadd -r ice && useradd -r -m -d /var/lib/ice -g ice ice
+
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+    ca-certificates \
+    curl \
+    gpg \
+    gosu \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://zeroc.com/download/GPG-KEY-zeroc-release-B6391CB2CFBA643D |  gpg --dearmor -o /etc/apt/keyrings/zeroc.gpg \
+    && echo \
+    "deb [signed-by=/etc/apt/keyrings/zeroc.gpg] https://zeroc.com/download/ice/3.7/ubuntu22.04 stable main" | tee /etc/apt/sources.list.d/zeroc-ice-3.7.list
+
+RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \
-        zeroc-icebox=${ICEBOX_VERSION}-* \
-        libzeroc-icestorm3.7=${ICEBOX_VERSION}-* \
-    && rm -rf /var/lib/apt/lists/*
+    zeroc-icebox=${ICEBOX_VERSION}-* \
+    libzeroc-icestorm3.7=${ICEBOX_VERSION}-* \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 VOLUME ["/data"]
 
-ENTRYPOINT ["/usr/bin/icebox", "--IceBox.Service.IceStorm=IceStormService,37:createIceStorm \
-                                                          --Ice.Config=/etc/icestorm.conf \
-                                                          --Freeze.DbEnv.IceStorm.DbHome=/data"]
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["icebox", "--IceBox.Service.IceStorm=IceStormService,37:createIceStorm", "--IceStorm.LMDB.Path=/data"]

--- a/3.7/icestorm/README.md
+++ b/3.7/icestorm/README.md
@@ -11,8 +11,16 @@
 
 ## Start `icestorm` service
 
+From a configuration file:
+
+```shell
+docker run --detach --name some-icestorm -v /path/to/config:/etc/icestorm.conf:ro zeroc/icestorm
 ```
-docker run --name some-icestorm -v /path/to/config:/etc/icestorm.conf:ro -d zeroc/icestorm
+
+From command line arguments:
+
+```shell
+docker run --detach --name some-icestorm zeroc/icestorm --IceStorm.TopicManager.Endpoints="tcp -h 0.0.0.0 -p 9999" --IceStorm.Publish.Endpoints="tcp -h 0.0.0.0 -p 10000"
 ```
 
 Refer to the  [IceStorm documentation](https://doc.zeroc.com/display/Ice/IceStorm) for more information on how to configure IceStorm.
@@ -20,81 +28,3 @@ Refer to the  [IceStorm documentation](https://doc.zeroc.com/display/Ice/IceStor
 ## Database volume
 
 The IceStorm container stores its data in a Docker volume mounted at `/data`.
-
-```
-docker run --name some-icestorm -v /path/to/config:/etc/icestorm.conf:ro -v/path/to/folder:/data -d zeroc/icestorm
-```
-
-## Sample Configuration
-
-```
-#
-# The IceStorm service instance name.
-#
-IceStorm.InstanceName=MyIceStorm
-
-#
-# This property defines the endpoints on which the IceStorm
-# TopicManager listens.
-#
-IceStorm.TopicManager.Endpoints=tcp -h <docker image name> -p 10000
-
-#
-# This property defines the endpoints on which the topic
-# publisher objects listen. If you want to federate
-# IceStorm instances this must run on a fixed port (or use
-# IceGrid).
-#
-IceStorm.Publish.Endpoints=tcp -h <docker image name> -p 10001:udp -h <docker image name> -p 10001
-#
-# TopicManager Tracing
-#
-# 0 = no tracing
-# 1 = trace topic creation, subscription, unsubscription
-# 2 = like 1, but with more detailed subscription information
-#
-IceStorm.Trace.TopicManager=2
-
-#
-# Topic Tracing
-#
-# 0 = no tracing
-# 1 = trace unsubscription diagnostics
-# 2 = like 1, but with more detailed subscription information
-#
-IceStorm.Trace.Topic=1
-
-#
-# Subscriber Tracing
-#
-# 0 = no tracing
-# 1 = subscriber diagnostics (subscription, unsubscription, event
-#     propagation failures)
-# 2 = like 1, but with more detailed subscription information
-#
-IceStorm.Trace.Subscriber=1
-
-#
-# Amount of time in milliseconds between flushes for batch mode
-# transfer. The minimum allowable value is 100ms.
-#
-IceStorm.Flush.Timeout=2000
-
-#
-# Network Tracing
-#
-# 0 = no network tracing
-# 1 = trace connection establishment and closure
-# 2 = like 1, but more detailed
-# 3 = like 2, but also trace data transfer
-#
-#Ice.Trace.Network=1
-
-#
-# IceMX configuration.
-#
-#Ice.Admin.Endpoints=tcp -h <docker image name> -p 10004
-Ice.Admin.InstanceName=icestorm
-IceMX.Metrics.Debug.GroupBy=id
-IceMX.Metrics.ByParent.GroupBy=parent
-```

--- a/3.7/icestorm/docker-entrypoint.sh
+++ b/3.7/icestorm/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+[ -e /data ] || mkdir /data
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- icebox --IceBox.Service.IceStorm=IceStormService,37:createIceStorm --IceStorm.LMDB.Path=/data "$@"
+fi
+
+if [ "$1" = "icebox" ]; then
+    echo "starting icestorm..."
+    chown -R ice:ice /data
+    exec gosu ice "$@"
+fi
+
+exec "$@"

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ endef
 
 define tag
 	docker tag zeroc/$1:latest zeroc/$1:3.7
-	docker tag zeroc/$1:latest zeroc/$1:3.7.8
+	docker tag zeroc/$1:latest zeroc/$1:3.7.9
 endef
 
 define push
 	docker push zeroc/$1:latest
 	docker push zeroc/$1:3.7
-	docker push zeroc/$1:3.7.8
+	docker push zeroc/$1:3.7.9
 endef
 
 .PHONY:build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+
+define build
+	cd 3.7/$1 && docker build --platform linux/amd64 -t zeroc/$1:latest -f Dockerfile .
+endef
+
+define tag
+	docker tag zeroc/$1:latest zeroc/$1:3.7
+	docker tag zeroc/$1:latest zeroc/$1:3.7.8
+endef
+
+define push
+	docker push zeroc/$1:latest
+	docker push zeroc/$1:3.7
+	docker push zeroc/$1:3.7.8
+endef
+
+.PHONY:build
+build:
+	@echo "Building..."
+	$(call build,glacier2)
+	$(call build,icegridnode)
+	$(call build,icegridregistry)
+	$(call build,icestorm)
+
+.PHONY:tag
+tag:
+	@echo "Tagging"
+	$(call tag,glacier2)
+	$(call tag,icegridnode)
+	$(call tag,icegridregistry)
+	$(call tag,icestorm)
+
+.PHONY:push
+push:
+	@echo "Pushing..."
+	$(call push,glacier2)
+	$(call push,icegridnode)
+	$(call push,icegridregistry)
+	$(call push,icestorm)


### PR DESCRIPTION
This PR reworks the Ice 3.7 `Dockerfile`s. Namely it does the following:

- Update base image to `ubuntu:22.04`
- Create and use an `ice` user
- Fix the default endpoints to use `0.0.0.0` instead of `localhost`
